### PR TITLE
Hopefully fix thread-unsafe GameMaker calls

### DIFF
--- a/Connection/MessageHandler.cs
+++ b/Connection/MessageHandler.cs
@@ -14,7 +14,8 @@ namespace RnSArchipelago.Connection
 {
     internal class MessageHandler
     {
-
+        internal Mod mod = null!;
+        
         private static readonly MessageHandler _instance = new MessageHandler();
 
         internal static MessageHandler Instance => _instance;
@@ -44,144 +45,153 @@ namespace RnSArchipelago.Connection
 
         internal unsafe void SendDisconnectedMessage()
         {
-            if (IsReady(out var rnsReloaded))
+            mod.RunOnGameThread(() =>
             {
-                var message = new RValue();
-                rnsReloaded.CreateString(&message, "Disconnected from the multiworld");
-                rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), message, new(0)]);
-            }
+                if (IsReady(out var rnsReloaded))
+                {
+                    var message = new RValue();
+                    rnsReloaded.CreateString(&message, "Disconnected from the multiworld");
+                    rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), message, new(0)]);
+                }
+            });
         }
 
         internal unsafe void OnMessageReceived(LogMessage message)
         {
-            if (IsReady(out var rnsReloaded))
+            mod.RunOnGameThread(() =>
             {
-                switch (message)
+                if (IsReady(out var rnsReloaded))
                 {
-                    case HintItemSendLogMessage hintLogMessage:
-                        var hintReceiver = hintLogMessage.Receiver;
-                        var hintSender = hintLogMessage.Sender;
-                        var hintNetworkItem = hintLogMessage.Item;
-                        var hintFound = hintLogMessage.IsFound;
+                    switch (message)
+                    {
+                        case HintItemSendLogMessage hintLogMessage:
+                            var hintReceiver = hintLogMessage.Receiver;
+                            var hintSender = hintLogMessage.Sender;
+                            var hintNetworkItem = hintLogMessage.Item;
+                            var hintFound = hintLogMessage.IsFound;
 
-                        if (modConfig?.SystemLog ?? false)
-                        {
-                            var hintMessage = new RValue();
-                            rnsReloaded.CreateString(&hintMessage, message.ToString());
-                            rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), hintMessage, new(0)]);
-                        }
-                        logger?.PrintMessage(hintLogMessage.ToString(), System.Drawing.Color.Cyan);
-                        break;
-                    case ItemSendLogMessage itemSendLogMessage:
-                        var receiver = itemSendLogMessage.Receiver;
-                        var sender = itemSendLogMessage.Sender;
-                        var networkItem = itemSendLogMessage.Item;
+                            if (modConfig?.SystemLog ?? false)
+                            {
+                                var hintMessage = new RValue();
+                                rnsReloaded.CreateString(&hintMessage, message.ToString());
+                                rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), hintMessage, new(0)]);
+                            }
+                            logger?.PrintMessage(hintLogMessage.ToString(), System.Drawing.Color.Cyan);
+                            break;
+                        case ItemSendLogMessage itemSendLogMessage:
+                            var receiver = itemSendLogMessage.Receiver;
+                            var sender = itemSendLogMessage.Sender;
+                            var networkItem = itemSendLogMessage.Item;
 
-                        var messageToSend = message.ToString();
-                        var sourceId = -1;
-                        if (itemSendLogMessage.IsSenderTheActivePlayer)
-                        {
-                            sourceId = 0;
-                            messageToSend = messageToSend.Remove(0, messageToSend.IndexOf(" "));
-                        }
+                            var messageToSend = message.ToString();
+                            var sourceId = -1;
+                            if (itemSendLogMessage.IsSenderTheActivePlayer)
+                            {
+                                sourceId = 0;
+                                messageToSend = messageToSend.Remove(0, messageToSend.IndexOf(" "));
+                            }
 
-                        var itemMessage = new RValue();
-                        if (modConfig != null && 
-                            (modConfig.OtherLog || itemSendLogMessage.IsRelatedToActivePlayer) &&
-                            ((modConfig.ProgressionLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Advancement)) ||
-                            (modConfig.UsefulLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.NeverExclude)) ||
-                            (modConfig.FillerLog && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Advancement) && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.NeverExclude) && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Trap)) ||
-                            (modConfig.TrapLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Trap))))
-                        {
-                            rnsReloaded.CreateString(&itemMessage, messageToSend);
-                            rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(sourceId), new(), new(0), itemMessage, new(0)]);
-                        }
-                        logger?.PrintMessage(message.ToString(), System.Drawing.Color.Cyan);
-                        break;
-                    case PlayerSpecificLogMessage playerLogMessage:
-                        var playerMessage = new RValue();
-                        if (modConfig?.SystemLog ?? false)
-                        {
-                            rnsReloaded.CreateString(&playerMessage, message.ToString());
-                            rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), playerMessage, new(0)]);
-                        }
-                        logger?.PrintMessage(message.ToString(), System.Drawing.Color.White);
-                        break;
-                    case AdminCommandResultLogMessage:
-                    case CommandResultLogMessage:
-                    case CountdownLogMessage:
-                    case ServerChatLogMessage:
-                    case TutorialLogMessage:
-                    default:
-                        if (modConfig?.SystemLog ?? false)
-                        {
-                            var gameMessage = new RValue();
-                            rnsReloaded.CreateString(&gameMessage, message.ToString());
-                            rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), gameMessage, new(0)]);
+                            var itemMessage = new RValue();
+                            if (modConfig != null && 
+                                (modConfig.OtherLog || itemSendLogMessage.IsRelatedToActivePlayer) &&
+                                ((modConfig.ProgressionLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Advancement)) ||
+                                 (modConfig.UsefulLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.NeverExclude)) ||
+                                 (modConfig.FillerLog && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Advancement) && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.NeverExclude) && !itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Trap)) ||
+                                 (modConfig.TrapLog && itemSendLogMessage.Item.Flags.HasFlag(ItemFlags.Trap))))
+                            {
+                                rnsReloaded.CreateString(&itemMessage, messageToSend);
+                                rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(sourceId), new(), new(0), itemMessage, new(0)]);
+                            }
+                            logger?.PrintMessage(message.ToString(), System.Drawing.Color.Cyan);
+                            break;
+                        case PlayerSpecificLogMessage playerLogMessage:
+                            var playerMessage = new RValue();
+                            if (modConfig?.SystemLog ?? false)
+                            {
+                                rnsReloaded.CreateString(&playerMessage, message.ToString());
+                                rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), playerMessage, new(0)]);
+                            }
                             logger?.PrintMessage(message.ToString(), System.Drawing.Color.White);
-                        }
-                        break;
+                            break;
+                        case AdminCommandResultLogMessage:
+                        case CommandResultLogMessage:
+                        case CountdownLogMessage:
+                        case ServerChatLogMessage:
+                        case TutorialLogMessage:
+                        default:
+                            if (modConfig?.SystemLog ?? false)
+                            {
+                                var gameMessage = new RValue();
+                                rnsReloaded.CreateString(&gameMessage, message.ToString());
+                                rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(0), new(0), gameMessage, new(0)]);
+                                logger?.PrintMessage(message.ToString(), System.Drawing.Color.White);
+                            }
+                            break;
+                    }
                 }
-            }
+            });
         }
 
         internal unsafe void OnPacketReceived(ArchipelagoPacketBase packet)
         {
-            if (IsReady(out var rnsReloaded))
+            mod.RunOnGameThread(() =>
             {
-                switch (packet.PacketType)
+                if (IsReady(out var rnsReloaded))
                 {
-                    case ArchipelagoPacketType.RoomInfo:
-                        // Save the seed so we can have a static random
-                        var room = (RoomInfoPacket)packet;
-                        this.data?.SetValue<object>(DataContext.Options, "seed", room.SeedName);
-                        break;
-                    case ArchipelagoPacketType.ConnectionRefused:
-                        var message = "Connection refused: " + string.Join(", ", ((ConnectionRefusedPacket)packet).Errors);
-                        var gameMessage = new RValue();
-                        rnsReloaded.CreateString(&gameMessage, message);
-                        rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(), new(0), gameMessage, new(0)]);
-                        this.logger?.PrintMessage(message, Color.Red);
-                        rnsReloaded.ExecuteScript("scr_runmenu_disband_disband", null, null, []);
-                        break;
-                    case ArchipelagoPacketType.Connected: // Get the options the user selected
-                        var connected = (ConnectedPacket)packet;
-                        slot = connected.Slot;
-                        foreach (var option in connected.SlotData)
-                        {
-                            this.logger?.PrintMessage(option.Key + " " + option.Value, System.Drawing.Color.DarkOrange);
-                            this.data?.SetValue<object>(DataContext.Options, option.Key, option.Value);
-                        }
-                        InventoryUtil.Instance.logger = this.logger;
-                        InventoryUtil.Instance.GetOptions();
-                        break;
-                    case ArchipelagoPacketType.ReceivedItems: // Actual printing message handled through OnMessageReceived, but actual mod use of items will be handled here
-                        var itemPacket = (ReceivedItemsPacket)packet;
-                        InventoryUtil.Instance.ReceiveItem(itemPacket);
-                        // Maybe have a subscriber pattern here or in inventoryutil to invoke a method for each received item type
-                        break;
-                    case ArchipelagoPacketType.LocationInfo:
-                    case ArchipelagoPacketType.RoomUpdate:
-                        break;
-                    case ArchipelagoPacketType.PrintJSON: // Handled through OnMessageReceived, so will likely never use
-                        break;
-                    case ArchipelagoPacketType.DataPackage:
-                        if (((DataPackagePacket)packet).DataPackage.Games.TryGetValue(GAME, out var gameData))
-                        {
-                            var itemId = gameData.ItemLookup;
-                            foreach (var item in itemId)
+                    switch (packet.PacketType)
+                    {
+                        case ArchipelagoPacketType.RoomInfo:
+                            // Save the seed so we can have a static random
+                            var room = (RoomInfoPacket)packet;
+                            this.data?.SetValue<object>(DataContext.Options, "seed", room.SeedName);
+                            break;
+                        case ArchipelagoPacketType.ConnectionRefused:
+                            var message = "Connection refused: " + string.Join(", ", ((ConnectionRefusedPacket)packet).Errors);
+                            var gameMessage = new RValue();
+                            rnsReloaded.CreateString(&gameMessage, message);
+                            rnsReloaded.ExecuteScript("scr_chat_add_message", null, null, [new RValue(-1), new(), new(0), gameMessage, new(0)]);
+                            this.logger?.PrintMessage(message, Color.Red);
+                            rnsReloaded.ExecuteScript("scr_runmenu_disband_disband", null, null, []);
+                            break;
+                        case ArchipelagoPacketType.Connected: // Get the options the user selected
+                            var connected = (ConnectedPacket)packet;
+                            slot = connected.Slot;
+                            foreach (var option in connected.SlotData)
                             {
-                                this.data?.SetValue<string>(DataContext.IdToItem, item.Value, item.Key);
+                                this.logger?.PrintMessage(option.Key + " " + option.Value, System.Drawing.Color.DarkOrange);
+                                this.data?.SetValue<object>(DataContext.Options, option.Key, option.Value);
                             }
-                        }
-                        break;
-                    case ArchipelagoPacketType.Bounced:
-                    case ArchipelagoPacketType.InvalidPacket:
-                    case ArchipelagoPacketType.Retrieved:
-                    case ArchipelagoPacketType.SetReply:
-                        break;
+                            InventoryUtil.Instance.logger = this.logger;
+                            InventoryUtil.Instance.GetOptions();
+                            break;
+                        case ArchipelagoPacketType.ReceivedItems: // Actual printing message handled through OnMessageReceived, but actual mod use of items will be handled here
+                            var itemPacket = (ReceivedItemsPacket)packet;
+                            InventoryUtil.Instance.ReceiveItem(itemPacket);
+                            // Maybe have a subscriber pattern here or in inventoryutil to invoke a method for each received item type
+                            break;
+                        case ArchipelagoPacketType.LocationInfo:
+                        case ArchipelagoPacketType.RoomUpdate:
+                            break;
+                        case ArchipelagoPacketType.PrintJSON: // Handled through OnMessageReceived, so will likely never use
+                            break;
+                        case ArchipelagoPacketType.DataPackage:
+                            if (((DataPackagePacket)packet).DataPackage.Games.TryGetValue(GAME, out var gameData))
+                            {
+                                var itemId = gameData.ItemLookup;
+                                foreach (var item in itemId)
+                                {
+                                    this.data?.SetValue<string>(DataContext.IdToItem, item.Value, item.Key);
+                                }
+                            }
+                            break;
+                        case ArchipelagoPacketType.Bounced:
+                        case ArchipelagoPacketType.InvalidPacket:
+                        case ArchipelagoPacketType.Retrieved:
+                        case ArchipelagoPacketType.SetReply:
+                            break;
+                    }
                 }
-            }
+            });
         }
     }
 }

--- a/Utils/ThreadBoundTaskScheduler.cs
+++ b/Utils/ThreadBoundTaskScheduler.cs
@@ -1,0 +1,97 @@
+﻿// taken from
+// https://github.com/goatcorp/Dalamud/blob/951290cac7f27ca67b76391649c5d9f0c38929bf/Dalamud/Utility/ThreadBoundTaskScheduler.cs
+
+using System.Collections.Concurrent;
+
+namespace RnSArchipelago.Utils;
+
+/// <summary>
+/// A task scheduler that runs tasks on a specific thread.
+/// </summary>
+internal class ThreadBoundTaskScheduler : TaskScheduler
+{
+    private const byte Scheduled = 0;
+    private const byte Running = 1;
+
+    private readonly ConcurrentDictionary<Task, byte> scheduledTasks = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThreadBoundTaskScheduler"/> class.
+    /// </summary>
+    /// <param name="boundThread">The thread to bind this task scheduelr to.</param>
+    public ThreadBoundTaskScheduler(Thread? boundThread = null)
+    {
+        this.BoundThread = boundThread;
+        this.TaskQueued += static () => { };
+    }
+
+    /// <summary>
+    /// Event fired when a task has been posted.
+    /// </summary>
+    public event Action TaskQueued;
+
+    /// <summary>
+    /// Gets or sets the thread this task scheduler is bound to.
+    /// </summary>
+    public Thread? BoundThread { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether we're on the bound thread.
+    /// </summary>
+    public bool IsOnBoundThread => Thread.CurrentThread == this.BoundThread;
+
+    /// <summary>
+    /// Runs queued tasks.
+    /// </summary>
+    public void Run()
+    {
+        foreach (var task in this.scheduledTasks.Keys)
+        {
+            if (!this.scheduledTasks.TryUpdate(task, Running, Scheduled))
+                continue;
+
+            _ = this.TryExecuteTask(task);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override IEnumerable<Task> GetScheduledTasks()
+    {
+        return this.scheduledTasks.Keys;
+    }
+
+    /// <inheritdoc/>
+    protected override void QueueTask(Task task)
+    {
+        this.TaskQueued.Invoke();
+        this.scheduledTasks[task] = Scheduled;
+    }
+
+    /// <inheritdoc/>
+    protected override bool TryDequeue(Task task)
+    {
+        if (!this.scheduledTasks.TryRemove(task, out _))
+            return false;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+    {
+        if (!this.IsOnBoundThread)
+            return false;
+
+        if (taskWasPreviouslyQueued && !this.scheduledTasks.TryUpdate(task, Running, Scheduled))
+            return false;
+
+        _ = this.TryExecuteTask(task);
+        return true;
+    }
+
+    private new bool TryExecuteTask(Task task)
+    {
+        var r = base.TryExecuteTask(task);
+        this.scheduledTasks.Remove(task, out _);
+        return r;
+    }
+}


### PR DESCRIPTION
This should(* haven't been able to test) move all the Archipelago packet handling over to the game thread. I _think_ the script I hooked `scr_should_update` runs once per frame: my monitor is 180Hz and I measured 73 calls over a (within human error) time period that felt like a third of a second.