### PR TITLE
Adding the Extra Mode content to the RnS mod

### DIFF
--- a/Game/KingdomHandler.cs
+++ b/Game/KingdomHandler.cs
@@ -1,12 +1,12 @@
 ﻿using Archipelago.MultiClient.Net.Packets;
 using Reloaded.Hooks.Definitions;
+using Reloaded.Mod.Interfaces;
 using Reloaded.Mod.Interfaces.Internal;
 using RnSArchipelago.Utils;
 using RNSReloaded.Interfaces;
 using RNSReloaded.Interfaces.Structs;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Reloaded.Mod.Interfaces;
 using static RnSArchipelago.Utils.HookUtil;
 
 namespace RnSArchipelago.Game
@@ -100,6 +100,27 @@ namespace RnSArchipelago.Game
                                     maxCanRun++;
                                 }
                                 break;
+                            case "hw_depths":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_depths");
+                                    maxCanRun++;
+                                }
+                                break;
+                            case "hw_aurum":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_aurum");
+                                    maxCanRun++;
+                                }
+                                break;
+                            case "hw_sanct":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_aurum");
+                                    maxCanRun++;
+                                }
+                                break;
                         }
                         if (runBefore != maxCanRun)
                         {
@@ -150,6 +171,27 @@ namespace RnSArchipelago.Game
                                 if ((visitableKingdoms & InventoryUtil.KingdomFlags.Red_Darkhouse) != 0)
                                 {
                                     accountedForKingdoms.Add("hw_lighthouse");
+                                    maxCanRun++;
+                                }
+                                break;
+                            case "hw_depths":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_depths");
+                                    maxCanRun++;
+                                }
+                                break;
+                            case "hw_aurum":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_aurum");
+                                    maxCanRun++;
+                                }
+                                break;
+                            case "hw_sanct":
+                                if ((visitableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
+                                {
+                                    accountedForKingdoms.Add("hw_sanct");
                                     maxCanRun++;
                                 }
                                 break;

--- a/Game/LocationHandler.cs
+++ b/Game/LocationHandler.cs
@@ -1049,7 +1049,7 @@ namespace RnSArchipelago.Game
                 kingdomName = kingdomName.Replace(Environment.NewLine, " ");
 
                 var notchName = GetNotchName(element);
-                if (notchName.Contains("Chest") && !kingdomName.Equals("Kingdom Outskirts"))
+                if (notchName.Contains("Chest") && !kingdomName.Equals("Kingdom Outskirts") && !kingdomName.Equals("Crack in the Geode"))
                 {
                     notchName = " Chest";
                 }
@@ -1057,6 +1057,7 @@ namespace RnSArchipelago.Game
                 {
                     return "Shira";
                 }
+
                 return kingdomName + notchName;
             }
             return "";
@@ -1081,7 +1082,7 @@ namespace RnSArchipelago.Game
                 kingdomName = kingdomName.Replace(Environment.NewLine, " ");
 
 
-                for (var i = kingdomName.Equals("Kingdom Outskirts") ? 1 : 0; i < notchPos; i++)
+                for (var i = kingdomName.Equals("Kingdom Outskirts") || kingdomName.Equals("Crack in the Geode") ? 1 : 0; i < notchPos; i++)
                 {
                     if (GetLocationType(i) == notchType)
                     {
@@ -1184,7 +1185,7 @@ namespace RnSArchipelago.Game
                 var kingdomName = rnsReloaded.FindValue(self, "stageName")->ToString();
                 kingdomName = kingdomName.Replace(Environment.NewLine, " ");
 
-                if (kingdomName.Equals("Kingdom Outskirts"))
+                if (kingdomName.Equals("Kingdom Outskirts") || kingdomName.Equals("Crack in the Geode"))
                 {
                     for (int i = 0; i < this.inventoryUtil.AvailableTreasurespheres; i++)
                     {

--- a/Utils/InventoryUtil.cs
+++ b/Utils/InventoryUtil.cs
@@ -188,21 +188,25 @@ namespace RnSArchipelago.Utils
         [Flags]
         internal enum ClassFlags
         {
-            None = 0b0000000000,
-            Wizard = 0b0000000001,
-            Assassin = 0b0000000010,
-            Heavyblade = 0b0000000100,
-            Dancer = 0b0000001000,
-            Druid = 0b0000010000,
-            Spellsword = 0b0000100000,
-            Sniper = 0b0001000000,
-            Bruiser = 0b0010000000,
-            Defender = 0b0100000000,
-            Ancient = 0b1000000000,
-            All = 0b1111111111
+            None = 0b00000000000000,
+            Wizard = 0b00000000000001,
+            Assassin = 0b00000000000010,
+            Heavyblade = 0b00000000000100,
+            Dancer = 0b00000000001000,
+            Druid = 0b00000000010000,
+            Spellsword = 0b00000000100000,
+            Sniper = 0b00000001000000,
+            Bruiser = 0b00000010000000,
+            Defender = 0b00000100000000,
+            Ancient = 0b00001000000000,
+            Hammermaid = 0b00010000000000,
+            Pyromancer = 0b00100000000000,
+            Gunner = 0b01000000000000,
+            Shadow = 0b10000000000000,
+            All = 0b11111111111111
         }
 
-        private static readonly string[] CLASSES = ["Wizard", "Assassin", "Heavyblade", "Dancer", "Druid", "Spellsword", "Sniper", "Bruiser", "Defender", "Ancient"];
+        private static readonly string[] CLASSES = ["Wizard", "Assassin", "Heavyblade", "Dancer", "Druid", "Spellsword", "Sniper", "Bruiser", "Defender", "Ancient", "Hammermaid", "Pyromancer", "Gunner", "Shadow"];
 
         internal ClassFlags AvailableClasses { get; set; }
 
@@ -991,6 +995,14 @@ namespace RnSArchipelago.Utils
                     return (AvailableClasses & InventoryUtil.ClassFlags.Defender) != 0;
                 case 9:
                     return (AvailableClasses & InventoryUtil.ClassFlags.Ancient) != 0;
+                case 10:
+                    return (AvailableClasses & InventoryUtil.ClassFlags.Hammermaid) != 0;
+                case 11:
+                    return (AvailableClasses & InventoryUtil.ClassFlags.Pyromancer) != 0;
+                case 12:
+                    return (AvailableClasses & InventoryUtil.ClassFlags.Gunner) != 0;
+                case 13:
+                    return (AvailableClasses & InventoryUtil.ClassFlags.Shadow) != 0;
             }
             return false;
         }

--- a/Utils/InventoryUtil.cs
+++ b/Utils/InventoryUtil.cs
@@ -168,19 +168,23 @@ namespace RnSArchipelago.Utils
         [Flags]
         internal enum KingdomFlags
         { 
-            None = 0b00000000,
-            Outskirts = 0b00000001,
-            Scholars_Nest = 0b00000010,
-            Kings_Arsenal = 0b00000100,
-            Red_Darkhouse = 0b00001000,
-            Churchmouse_Streets = 0b00010000,
-            Emerald_Lakeside = 0b00100000,
-            The_Pale_Keep = 0b01000000,
-            Moonlit_Pinnacle = 0b10000000,
-            All = 0b11111111
+            None = 0b000000000000,
+            Outskirts = 0b000000000001,
+            Crack_in_the_Geode = 0b00000000010,
+            Scholars_Nest = 0b000000000100,
+            Kings_Arsenal = 0b000000001000,
+            Red_Darkhouse = 0b000000010000,
+            Churchmouse_Streets = 0b000000100000,
+            Emerald_Lakeside = 0b000001000000,
+            Darkhouse_Depths = 0b000010000000,
+            Atelier_Aurum = 0b000100000000,
+            Subterra_Sanctum = 0b001000000000,
+            The_Pale_Keep = 0b010000000000,
+            Moonlit_Pinnacle = 0b100000000000,
+            All = 0b111111111111
         }
 
-        private static readonly string[] KINGDOMS = ["Kingdom Outskirts", "Scholar's Nest", "King's Arsenal", "Red Darkhouse", "Churchmouse Streets", "Emerald Lakeside", "The Pale Keep", "Moonlit Pinnacle"];
+        private static readonly string[] KINGDOMS = ["Kingdom Outskirts", "Crack in the Geode", "Scholar's Nest", "King's Arsenal", "Red Darkhouse", "Churchmouse Streets", "Emerald Lakeside", "Darkhouse Depths", "Atelier Aurum", "Subterra Sanctum", "The Pale Keep", "Moonlit Pinnacle"];
 
         internal KingdomFlags AvailableKingdoms { get; set; }
         internal int ProgressiveRegions { get; set; }
@@ -201,12 +205,12 @@ namespace RnSArchipelago.Utils
             Ancient = 0b00001000000000,
             Hammermaid = 0b00010000000000,
             Pyromancer = 0b00100000000000,
-            Gunner = 0b01000000000000,
+            Grenadier = 0b01000000000000,
             Shadow = 0b10000000000000,
             All = 0b11111111111111
         }
 
-        private static readonly string[] CLASSES = ["Wizard", "Assassin", "Heavyblade", "Dancer", "Druid", "Spellsword", "Sniper", "Bruiser", "Defender", "Ancient", "Hammermaid", "Pyromancer", "Gunner", "Shadow"];
+        private static readonly string[] CLASSES = ["Wizard", "Assassin", "Heavyblade", "Dancer", "Druid", "Spellsword", "Sniper", "Bruiser", "Defender", "Ancient", "Hammermaid", "Pyromancer", "Grenadier", "Shadow"];
 
         internal ClassFlags AvailableClasses { get; set; }
 
@@ -820,6 +824,18 @@ namespace RnSArchipelago.Utils
             {
                 return "hw_lighthouse";
             }
+            if (name == "Darkhouse Depths")
+            {
+                return "hw_depths";
+            }
+            if (name == "Atelier Aurum")
+            {
+                return "hw_aurum";
+            }
+            if (name == "Subterra Sanctum")
+            {
+                return "hw_sanct";
+            }
             return "";
         }
 
@@ -849,6 +865,18 @@ namespace RnSArchipelago.Utils
                 if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Red_Darkhouse) != 0)
                 {
                     kingdoms.Add("hw_lighthouse");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                {
+                    kingdoms.Add("hw_depths");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                {
+                    kingdoms.Add("hw_aurum");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
+                {
+                    kingdoms.Add("hw_sanct");
                 }
             }
             else
@@ -892,6 +920,18 @@ namespace RnSArchipelago.Utils
                 {
                     kingdoms.Add("hw_lighthouse");
                 }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                {
+                    kingdoms.Add("hw_depths");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                {
+                    kingdoms.Add("hw_aurum");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
+                {
+                    kingdoms.Add("hw_sanct");
+                }
             }
             else if (isProgressive || (isKingdomSanity && useKingdomOrderWithKingdomSanity))
             {
@@ -914,6 +954,18 @@ namespace RnSArchipelago.Utils
                         kingdoms.Add(kingdom);
                     }
                     if (kingdom == "hw_lighthouse" && (AvailableKingdoms & InventoryUtil.KingdomFlags.Red_Darkhouse) != 0)
+                    {
+                        kingdoms.Add(kingdom);
+                    }
+                    if (kingdom == "hw_depths" && (AvailableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                    {
+                        kingdoms.Add(kingdom);
+                    }
+                    if (kingdom == "hw_aurum" && (AvailableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                    {
+                        kingdoms.Add(kingdom);
+                    }
+                    if (kingdom == "hw_sanct" && (AvailableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
                     {
                         kingdoms.Add(kingdom);
                     }
@@ -940,6 +992,18 @@ namespace RnSArchipelago.Utils
                 {
                     kingdoms.Add("hw_lighthouse");
                 }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+                {
+                    kingdoms.Add("hw_depths");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+                {
+                    kingdoms.Add("hw_aurum");
+                }
+                if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
+                {
+                    kingdoms.Add("hw_sanct");
+                }
             }
             return kingdoms;
         }
@@ -965,6 +1029,18 @@ namespace RnSArchipelago.Utils
                 count++;
             }
             if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Red_Darkhouse) != 0)
+            {
+                count++;
+            }
+            if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Darkhouse_Depths) != 0)
+            {
+                count++;
+            }
+            if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Atelier_Aurum) != 0)
+            {
+                count++;
+            }
+            if ((AvailableKingdoms & InventoryUtil.KingdomFlags.Subterra_Sanctum) != 0)
             {
                 count++;
             }
@@ -1000,7 +1076,7 @@ namespace RnSArchipelago.Utils
                 case 11:
                     return (AvailableClasses & InventoryUtil.ClassFlags.Pyromancer) != 0;
                 case 12:
-                    return (AvailableClasses & InventoryUtil.ClassFlags.Gunner) != 0;
+                    return (AvailableClasses & InventoryUtil.ClassFlags.Grenadier) != 0;
                 case 13:
                     return (AvailableClasses & InventoryUtil.ClassFlags.Shadow) != 0;
             }


### PR DESCRIPTION
Adding the new classes and regions to the RnS mod.

Yet to be implemented:
* Changes to the UI to allow for selection of Kingdom Outskirts/Crack in the Geode (Selecting the appropriate region in the route plan works correctly, but the override code to change regions during gameplay does not.)
* Looping Hallway and Reflecting Pool (currently, all paths lead to the Pale Keep.)
* New Item Sets

Untested:
* Potential changes to kingdom order logic - I don't expect any, but I don't fully understand how kingdom order is intended to work, so I don't know how to properly test it.